### PR TITLE
Update logfile_viewer.html for Django 3.0

### DIFF
--- a/log_viewer/templates/log_viewer/logfile_viewer.html
+++ b/log_viewer/templates/log_viewer/logfile_viewer.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load admin_static i18n %}
+{% load static i18n %}
 
 {% block breadcrumbs %}
   <div class="breadcrumbs">


### PR DESCRIPTION
`load admin_static` was deprecated in favor of `load static` and completely removed in Django 3.0