### PR TITLE
Fix: escape the HTML entity

### DIFF
--- a/log_viewer/templates/log_viewer/logfile_viewer.html
+++ b/log_viewer/templates/log_viewer/logfile_viewer.html
@@ -60,6 +60,22 @@
   </div>
 
   <script>
+    var entityMap = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;',
+      '/': '&#x2F;',
+      '`': '&#x60;',
+      '=': '&#x3D;'
+    };
+    function escapeHtml (string) {
+      return String(string).replace(/[&<>"'`=\/]/g, function fromEntityMap (s) {
+        return entityMap[s];
+      });
+    }
+
     function loadDataTable(table_name, url_json) {
       $(table_name).DataTable({
         pageLength: {{ page_length }},
@@ -73,7 +89,8 @@
                 var next_page = response.next_page || 1;
 
                 response.logs.forEach(function(text, numb, logs){
-                  new_logs.push([numb+1, text])
+                  text = escapeHtml(text);
+                  new_logs.push([numb+1, text]);
                 });
 
                 callback({


### PR DESCRIPTION
resolve #16

If log texts contain HTML tags then texts are not shown correctly.

So, Add code to escape the HTML entity.
