### PR TITLE
Include CSP nonce in log_viewer template

### DIFF
--- a/log_viewer/templates/log_viewer/logfile_viewer.html
+++ b/log_viewer/templates/log_viewer/logfile_viewer.html
@@ -67,7 +67,7 @@
     </div>
   </div>
 
-  <script>
+  <script nonce="{{request.csp_nonce}}">
     var entityMap = {
       '&': '&amp;',
       '<': '&lt;',


### PR DESCRIPTION
For the log viewer to work correctly with applications using django-csp, a nonce has to be added to the script tag.