### PR TITLE
Fix bug multiple duplicated characters printed - Non-english languages

### DIFF
--- a/log_viewer/utils.py
+++ b/log_viewer/utils.py
@@ -91,8 +91,12 @@ def readlines_reverse(qfile, exclude=None):
                     line = ""
         else:
             line += next_char
-        char_len = len(next_char.encode())
-        position -= char_len or 1
+
+        char_length = len(next_char.encode())
+        if char_length > 1 and len(line) > 3 and len(set(line[-4:-1])) == 1:
+            line = line[:-3] + next_char
+        position -= char_length or 1
+
     yield line[::-1]
 
 

--- a/log_viewer/utils.py
+++ b/log_viewer/utils.py
@@ -91,7 +91,8 @@ def readlines_reverse(qfile, exclude=None):
                     line = ""
         else:
             line += next_char
-        position -= 1
+        char_len = len(next_char.encode())
+        position -= char_len or 1
     yield line[::-1]
 
 


### PR DESCRIPTION
### Non-English charters contains more than 1 byte.

So I FIxed it to seek over 1 bytes depends on the length of the charater.

<img width="167" alt="image" src="https://github.com/agusmakmun/django-log-viewer/assets/18394695/3a0ada6e-ea8e-43d1-a272-b9c0fc8db299">


---


| Has bug | Fixed |
| - | - |
| ![image](https://github.com/agusmakmun/django-log-viewer/assets/18394695/2be09a96-c417-4fd5-810c-2d0006c4376e) | ![image](https://github.com/agusmakmun/django-log-viewer/assets/18394695/c29b1913-257d-473b-aa30-aa5d0b0c8e3f) |

---

* This PR fixes https://github.com/agusmakmun/django-log-viewer/issues/40
