### PR TITLE
fix: use underscore 'description_file' name in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal = 1
 
 [metadata]
-description-file = README.rst
+description_file = README.rst
 
 [flake8]
 ignore = E402,E501,W503,W504,E731,E741


### PR DESCRIPTION
Fixes #42 