### PR TITLE
fix: allow `get_log_files` to collect logs from multiple directories

### DIFF
--- a/log_viewer/tests/tests.py
+++ b/log_viewer/tests/tests.py
@@ -1,3 +1,4 @@
+import os
 import types
 import tempfile
 from itertools import islice
@@ -36,14 +37,24 @@ class TestLogsViewer(TestCase):
         self.assertTemplateUsed(response, "log_viewer/logfile_viewer.html")
 
     def test_get_log_files(self):
-        with tempfile.TemporaryDirectory() as log_dir:
-            open("%s/default.log" % log_dir, "a").close()
-            result = get_log_files(log_dir, 1, 1)
+        with tempfile.TemporaryDirectory() as parent_level_log_dir, \
+                tempfile.TemporaryDirectory(dir=parent_level_log_dir) as child_one_log_dir, \
+                tempfile.TemporaryDirectory(dir=parent_level_log_dir) as child_two_log_dir:
+            open("%s/default.log" % parent_level_log_dir, "a").close()
+            open("%s/a.log" % child_one_log_dir, "a").close()
+            open("%s/b.log" % child_two_log_dir, "a").close()
+
+            child_one_relative_path = os.path.relpath(child_one_log_dir, parent_level_log_dir)
+            child_two_relative_path = os.path.relpath(child_two_log_dir, parent_level_log_dir)
+
+            result = get_log_files(parent_level_log_dir, 2, 1)
             self.assertEqual(
                 result,
                 {
                     "logs": {
                         "": ["default.log"],
+                        child_one_relative_path: ["a.log"],
+                        child_two_relative_path: ["b.log"],
                     },
                     "next_page_files": 2,
                     "last_files": True,

--- a/log_viewer/utils.py
+++ b/log_viewer/utils.py
@@ -27,25 +27,22 @@ def get_log_files(directory, max_items_per_page, current_page):
     }
     >>>
     """
-    result = {}
-    all_log_files = []
+    result = {"logs": {}}
     for root, _, files in os.walk(directory):
         all_files = list(filter(lambda x: x.find("~") == -1, files))
 
-        all_log_files.extend(
-            list(filter(lambda x: x in settings.LOG_VIEWER_FILES, all_files))
-        )
-        all_log_files.extend(
+        log_files = list(filter(lambda x: x in settings.LOG_VIEWER_FILES, all_files))
+        log_files.extend(
             [x for x in all_files if fnmatch(x, settings.LOG_VIEWER_FILES_PATTERN)]
         )
         log_dir = os.path.relpath(root, directory)
         if log_dir == ".":
             log_dir = ""
 
-        result["logs"] = {log_dir: list(set(all_log_files))}
+        result["logs"][log_dir] = list(set(log_files))
         result["next_page_files"] = current_page + 1
         result["last_files"] = (
-            all_log_files.__len__() <= current_page * max_items_per_page
+                log_files.__len__() <= current_page * max_items_per_page
         )
 
     return result


### PR DESCRIPTION
`get_log_files()` does go through subdirectories under `LOG_VIEWER_FILES_DIR`.
However, `result["logs"]` is getting overwritten everytime and logs from only one subdirectory is visible to the user.

Resolves: #44